### PR TITLE
harness(backlog): parseable STORY-001..005 + state-machine validator

### DIFF
--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -115,3 +115,10 @@ development_status:
   7-3-ui-rom-type-badge-filter: ready-for-dev
   7-4-rom-type-tests: ready-for-dev
   epic-7-retrospective: optional
+
+  # ── Harness — Hardening ───────────────────────────────────────────────────────
+  STORY-001-structured-logger: ready-for-dev
+  STORY-002-savestate-roundtrip-test: ready-for-dev
+  STORY-003-zod-ipc-contracts: ready-for-dev
+  STORY-004-drizzle-migration-runner: ready-for-dev
+  STORY-005-tech-debt-audit: ready-for-dev

--- a/_bmad-output/implementation-artifacts/stories/backlog/STORY-001-structured-logger.md
+++ b/_bmad-output/implementation-artifacts/stories/backlog/STORY-001-structured-logger.md
@@ -1,0 +1,30 @@
+# Story STORY-001: Cross-Platform Structured Logger
+
+**Status**: ready-for-dev
+**Epic**: Harness — Hardening
+**Estimate**: 4h
+**Priority**: High
+
+## User Story
+As a developer, I want a cross-platform structured logger in `@emuz/core`, so that desktop and mobile code can emit leveled, namespaced, JSON-formatted logs through a pluggable transport instead of scattered `console.*` calls.
+
+## Acceptance Criteria
+- [ ] `createLogger(namespace: string)` factory exported from `libs/core/src/services` returns a `Logger` with methods `debug`, `info`, `warn`, `error`, each accepting `(message: string, context?: Record<string, unknown>)`
+- [ ] Log levels are ordered `debug < info < warn < error`; a configurable minimum level filters out lower-severity records (default `info`)
+- [ ] Each emitted record is a JSON object containing at minimum `timestamp` (ISO-8601), `level`, `namespace`, `message`, and a flattened `context`
+- [ ] A `child(subNamespace: string)` method returns a logger whose namespace is `parent:child`
+- [ ] Output is delivered via a pluggable `LogTransport` interface (`write(record: LogRecord): void`); the default transport is injectable so desktop and mobile can supply their own
+- [ ] All filesystem or platform IO performed by any transport goes through `@emuz/platform` adapters — the core logger itself performs no direct IO
+- [ ] No `console.*` calls remain in `libs/` shared code paths touched by this story; an ESLint `no-console` assertion or unit test guards this
+- [ ] Unit tests in `libs/core/src/__tests__/Logger.test.ts` cover: level filtering, JSON record shape, namespace/child composition, custom transport invocation, and that context is included
+- [ ] `Logger`, `LogRecord`, `LogLevel`, and `LogTransport` types are exported from `libs/core/src/index.ts`
+
+## Technical Notes
+- **Architecture ref**: architecture.md — cross-platform `libs/` rules (no platform-specific code, IO via `@emuz/platform`)
+- **PRD ref**: NFR — observability / no user data collection (logs stay local)
+- **Dependencies**: none
+- **Key files**:
+  - `libs/core/src/services/Logger.ts` (new)
+  - `libs/core/src/__tests__/Logger.test.ts` (new)
+  - `libs/core/src/index.ts` (export new types)
+- **TDD cycle**: write level/shape/transport tests → red → implement logger + transport interface → green → refactor

--- a/_bmad-output/implementation-artifacts/stories/backlog/STORY-002-savestate-roundtrip-test.md
+++ b/_bmad-output/implementation-artifacts/stories/backlog/STORY-002-savestate-roundtrip-test.md
@@ -1,0 +1,28 @@
+# Story STORY-002: Savestate Persistence Round-Trip Test
+
+**Status**: ready-for-dev
+**Epic**: Harness — Hardening
+**Estimate**: 3h
+**Priority**: High
+
+## User Story
+As a developer, I want a real round-trip test for savestate persistence, so that I can trust that a saved state can be written and read back byte-for-byte equal, and that corrupt or missing states fail gracefully.
+
+## Acceptance Criteria
+- [ ] A round-trip test writes a representative savestate payload, reads it back, and asserts `deepEqual` between the original and the loaded value
+- [ ] The test exercises the actual savestate service/persistence path used by the app (not a mock of the code under test); only `@emuz/platform` IO is faked/tempdir-backed
+- [ ] A reusable test fixture (a known savestate payload, e.g. JSON or binary buffer) lives under the test directory and is documented inline
+- [ ] Edge case: reading a missing savestate returns a typed "not found" result (or throws a documented error) rather than crashing — covered by an assertion
+- [ ] Edge case: reading a corrupt/truncated savestate surfaces a clear, typed error and does not return partial garbage — covered by an assertion
+- [ ] Round-trip covers nested/structured state (objects, arrays, numbers, strings) to prove no lossy serialization
+- [ ] Test is deterministic (no real wall-clock or random-dependent assertions) and cleans up any temp files it creates
+- [ ] Test runs under Vitest via `pnpm nx test core` (or the owning lib) and passes
+
+## Technical Notes
+- **Architecture ref**: architecture.md — `@emuz/platform` filesystem adapter; no synchronous file ops on main thread
+- **PRD ref**: savestate persistence requirement
+- **Dependencies**: locate the existing savestate service in `libs/core/src/services` (or relevant lib) before writing the test
+- **Key files**:
+  - `libs/core/src/__tests__/SavestateRoundtrip.test.ts` (new — adjust path to owning lib if savestate lives elsewhere)
+  - test fixture file colocated under the test directory (new)
+- **TDD cycle**: this story IS the test; write round-trip + edge-case assertions → run against current implementation → file follow-up if a real defect is found

--- a/_bmad-output/implementation-artifacts/stories/backlog/STORY-003-zod-ipc-contracts.md
+++ b/_bmad-output/implementation-artifacts/stories/backlog/STORY-003-zod-ipc-contracts.md
@@ -1,0 +1,35 @@
+# Story STORY-003: Zod-Validated Electron IPC Contracts
+
+**Status**: ready-for-dev
+**Reserved**: supervised
+**Epic**: Harness — Hardening
+**Estimate**: 6h
+**Priority**: Medium
+
+**RESERVED — supervised mode only, do not implement autonomously.**
+
+## User Story
+As a desktop developer, I want every Electron main↔renderer IPC message validated by a shared Zod schema, so that malformed or malicious payloads crossing the process boundary are rejected before reaching handler logic.
+
+## Acceptance Criteria
+- [ ] A shared Zod schema is defined for the request payload and the response of every IPC channel exposed by the four handler modules
+- [ ] `apps/desktop/src/main/ipc/database.ts` validates inbound args with `schema.parse`/`safeParse` and rejects invalid payloads with a typed error before touching the database
+- [ ] `apps/desktop/src/main/ipc/filesystem.ts` validates inbound args (including path inputs) before any filesystem access; invalid input is rejected (defends against directory traversal)
+- [ ] `apps/desktop/src/main/ipc/launcher.ts` validates inbound args before launching any emulator process
+- [ ] `apps/desktop/src/main/ipc/storage.ts` validates inbound args before any storage read/write
+- [ ] `apps/desktop/src/preload/index.ts` exposes only the validated, typed channel surface; the renderer cannot invoke an unlisted channel
+- [ ] Schemas are colocated/shared so the preload bridge and main handlers import the same source of truth (no drift between renderer-facing types and main validation)
+- [ ] Unit tests prove each channel rejects at least one invalid payload shape and accepts a valid one
+- [ ] No raw `ipcMain.handle` callback consumes its `args` without first running them through the channel's Zod schema
+
+## Technical Notes
+- **Architecture ref**: architecture.md — IPC bridge between Electron main and renderer; security rule "validate all file paths (prevent directory traversal)"
+- **PRD ref**: desktop security / IPC hardening
+- **Dependencies**: none — additive validation layer over existing handlers
+- **Current files (reference)**:
+  - `apps/desktop/src/main/ipc/database.ts`
+  - `apps/desktop/src/main/ipc/filesystem.ts`
+  - `apps/desktop/src/main/ipc/launcher.ts`
+  - `apps/desktop/src/main/ipc/storage.ts`
+  - `apps/desktop/src/preload/index.ts`
+- **TDD cycle**: write per-channel accept/reject schema tests → red → wire `safeParse` into each handler + preload surface → green → refactor shared schema module

--- a/_bmad-output/implementation-artifacts/stories/backlog/STORY-004-drizzle-migration-runner.md
+++ b/_bmad-output/implementation-artifacts/stories/backlog/STORY-004-drizzle-migration-runner.md
@@ -1,0 +1,32 @@
+# Story STORY-004: Versioned Drizzle Migration Runner (up/down)
+
+**Status**: ready-for-dev
+**Reserved**: supervised
+**Epic**: Harness — Hardening
+**Estimate**: 6h
+**Priority**: Medium
+
+**RESERVED — supervised mode only, do not implement autonomously.**
+
+## User Story
+As a developer, I want a versioned Drizzle migration runner with both `up` and `down` support in `@emuz/database`, so that schema changes can be applied and rolled back deterministically across desktop and mobile.
+
+## Acceptance Criteria
+- [ ] A migration runner exported from `libs/database/src` applies pending `up` migrations in version order against a `DrizzleDb` instance
+- [ ] Each migration is versioned and recorded in a tracking table so already-applied migrations are skipped (idempotent re-run)
+- [ ] A `down` path reverts the most recently applied migration (or down-to a target version) and updates the tracking table accordingly
+- [ ] Running the runner on a fresh database brings the schema to the latest version; running it again is a no-op
+- [ ] The runner is transport-agnostic: it accepts a `DrizzleDb` so the same logic works for better-sqlite3 (desktop) and react-native-sqlite-storage (mobile)
+- [ ] Errors during a migration leave the tracking table consistent (a failed migration is not marked applied)
+- [ ] Unit tests cover: fresh up, idempotent re-run, single down/rollback, and ordering of multiple migrations
+- [ ] No direct synchronous filesystem access on a main thread; IO goes through existing database adapters
+
+## Technical Notes
+- **Architecture ref**: architecture.md §ADR-013 (Drizzle ORM; `DrizzleDb` from `@emuz/database`; legacy `DatabaseAdapter` deprecated)
+- **PRD ref**: database migration / schema versioning
+- **Dependencies**: Story 1.7 (Drizzle ORM migration) and existing `libs/database/src/migrations`
+- **Key files**:
+  - `libs/database/src/migrations/` (runner + version registry)
+  - `libs/database/src/index.ts` (export runner)
+  - `libs/database/src/__tests__/` (new runner tests)
+- **TDD cycle**: write up/down/idempotency tests against an in-memory DrizzleDb → red → implement runner + tracking table → green → refactor

--- a/_bmad-output/implementation-artifacts/stories/backlog/STORY-005-tech-debt-audit.md
+++ b/_bmad-output/implementation-artifacts/stories/backlog/STORY-005-tech-debt-audit.md
@@ -1,0 +1,25 @@
+# Story STORY-005: Tech-Debt Audit (Read-Only Canary)
+
+**Status**: ready-for-dev
+**Epic**: Harness — Hardening
+**Estimate**: XS
+**Priority**: Low
+
+## User Story
+As a maintainer, I want to run the `tech-debt` skill to produce an audit report, so that I have an up-to-date inventory of code smells and debt — produced without changing any application code (read-only canary for the harness).
+
+## Acceptance Criteria
+- [ ] The `tech-debt` skill at `.claude/skills/tech-debt/` is invoked to scan the repository
+- [ ] An audit report is produced summarizing findings (e.g. count by severity, hotspots, suggested follow-up stories)
+- [ ] NO application source file is modified — no edits under `apps/`, `libs/`, `scripts/`, or any config file
+- [ ] `libs/ui/src/themes/*` and any `__generated__/` file are explicitly left untouched
+- [ ] `git status` after running the skill shows zero changes to tracked application files (only the new report artifact, if any, is added)
+- [ ] The report is written to a non-source location (e.g. `_bmad-output/`) so it does not affect builds or tests
+- [ ] No dependencies are added and `package.json` is not edited
+
+## Technical Notes
+- **Skill ref**: `.claude/skills/tech-debt/` (provided by harness component D)
+- **Architecture ref**: harness hardening — read-only validation canary
+- **Dependencies**: requires the `tech-debt` skill (component D) to be present
+- **Key files**: none modified — output report only, under `_bmad-output/`
+- **Note**: This story is intentionally a no-op against application code; its purpose is to prove the autonomous loop can run a read-only skill safely.

--- a/scripts/bmad-backlog.mjs
+++ b/scripts/bmad-backlog.mjs
@@ -1,0 +1,177 @@
+#!/usr/bin/env node
+// bmad-backlog.mjs — parse + validate the BMAD backlog stories.
+// Node ESM, built-ins only. No external dependencies.
+//
+// Usage:
+//   node scripts/bmad-backlog.mjs --validate   # validate + print index (stdout) + summary (stderr)
+//   node scripts/bmad-backlog.mjs --json       # emit only the JSON index to stdout
+//
+// Exit codes: 0 = all stories valid; non-zero = at least one malformed story.
+
+import { readFileSync, readdirSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join, basename } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(__dirname, '..');
+const BACKLOG_DIR = join(
+  REPO_ROOT,
+  '_bmad-output',
+  'implementation-artifacts',
+  'stories',
+  'backlog',
+);
+
+const VALID_STATUSES = ['backlog', 'ready-for-dev', 'in-progress', 'review', 'done'];
+const REQUIRED_SECTIONS = ['## User Story', '## Acceptance Criteria', '## Technical Notes'];
+
+/**
+ * Parse a single story markdown file into a structured record.
+ * @param {string} filePath
+ * @returns {{ file: string, title: string|null, status: string|null, epic: string|null,
+ *   reserved: boolean, acTotal: number, acChecked: number, acOpen: number,
+ *   missingSections: string[], errors: string[] }}
+ */
+function parseStory(filePath) {
+  const text = readFileSync(filePath, 'utf8');
+  const lines = text.split(/\r?\n/);
+  const errors = [];
+
+  // Title: first H1 of form "# Story <id>: <title>"
+  const titleLine = lines.find((l) => /^#\s+Story\s+/.test(l));
+  let title = null;
+  if (titleLine) {
+    title = titleLine.replace(/^#\s+/, '').trim();
+  } else {
+    errors.push('missing "# Story <id>: <title>" heading');
+  }
+
+  // **Status**: <value>
+  const statusMatch = text.match(/^\*\*Status\*\*:\s*(.+)$/m);
+  const status = statusMatch ? statusMatch[1].trim() : null;
+  if (!status) {
+    errors.push('missing **Status** line');
+  } else if (!VALID_STATUSES.includes(status)) {
+    errors.push(
+      `invalid status "${status}" (expected one of: ${VALID_STATUSES.join(', ')})`,
+    );
+  }
+
+  // **Epic**: <value>
+  const epicMatch = text.match(/^\*\*Epic\*\*:\s*(.+)$/m);
+  const epic = epicMatch ? epicMatch[1].trim() : null;
+  if (!epic) errors.push('missing **Epic** line');
+
+  // **Reserved**: supervised  (optional)
+  const reserved = /^\*\*Reserved\*\*:\s*supervised\s*$/m.test(text);
+
+  // Acceptance criteria checkboxes.
+  let acChecked = 0;
+  let acOpen = 0;
+  for (const l of lines) {
+    if (/^\s*-\s*\[x\]\s+/i.test(l)) acChecked += 1;
+    else if (/^\s*-\s*\[ \]\s+/.test(l)) acOpen += 1;
+  }
+  const acTotal = acChecked + acOpen;
+  if (acTotal === 0) errors.push('no acceptance criteria ("- [ ]" / "- [x]") found');
+
+  // Required sections.
+  const missingSections = REQUIRED_SECTIONS.filter(
+    (sec) => !lines.some((l) => l.trim() === sec),
+  );
+  for (const sec of missingSections) {
+    errors.push(`missing required section "${sec}"`);
+  }
+
+  return {
+    file: basename(filePath),
+    title,
+    status,
+    epic,
+    reserved,
+    acTotal,
+    acChecked,
+    acOpen,
+    missingSections,
+    errors,
+  };
+}
+
+function collectStories() {
+  let entries;
+  try {
+    entries = readdirSync(BACKLOG_DIR);
+  } catch (err) {
+    process.stderr.write(`error: cannot read backlog dir ${BACKLOG_DIR}: ${err.message}\n`);
+    process.exit(2);
+  }
+  const files = entries
+    .filter((f) => f.endsWith('.md'))
+    .sort()
+    .map((f) => join(BACKLOG_DIR, f));
+  return files.map(parseStory);
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  const jsonOnly = args.includes('--json');
+  const validate = args.includes('--validate');
+
+  if (!jsonOnly && !validate) {
+    process.stderr.write(
+      'usage: node scripts/bmad-backlog.mjs [--validate | --json]\n',
+    );
+    process.exit(2);
+  }
+
+  const stories = collectStories();
+  const valid = stories.filter((s) => s.errors.length === 0);
+  const invalid = stories.filter((s) => s.errors.length > 0);
+
+  const index = {
+    generatedAt: new Date().toISOString(),
+    backlogDir: '_bmad-output/implementation-artifacts/stories/backlog',
+    total: stories.length,
+    valid: valid.length,
+    invalid: invalid.length,
+    stories: stories.map((s) => ({
+      file: s.file,
+      title: s.title,
+      status: s.status,
+      epic: s.epic,
+      reserved: s.reserved,
+      acceptanceCriteria: { total: s.acTotal, checked: s.acChecked, open: s.acOpen },
+      ok: s.errors.length === 0,
+      errors: s.errors,
+    })),
+  };
+
+  // Machine-readable index always goes to stdout.
+  process.stdout.write(JSON.stringify(index, null, jsonOnly ? 0 : 2) + '\n');
+
+  if (jsonOnly) {
+    process.exit(invalid.length === 0 ? 0 : 1);
+  }
+
+  // Human summary to stderr.
+  const out = process.stderr;
+  out.write('\nBMAD backlog validation\n');
+  out.write('=======================\n');
+  for (const s of stories) {
+    const mark = s.errors.length === 0 ? 'OK ' : 'BAD';
+    const reservedTag = s.reserved ? ' [RESERVED:supervised]' : '';
+    out.write(
+      `[${mark}] ${s.file} — ${s.title ?? '(no title)'} ` +
+        `(status=${s.status ?? '?'}, AC ${s.acChecked}/${s.acTotal})${reservedTag}\n`,
+    );
+    for (const e of s.errors) out.write(`        ! ${e}\n`);
+  }
+  out.write(
+    `\n${valid.length}/${stories.length} stories valid` +
+      (invalid.length ? `, ${invalid.length} malformed\n` : '\n'),
+  );
+
+  process.exit(invalid.length === 0 && stories.length > 0 ? 0 : 1);
+}
+
+main();


### PR DESCRIPTION
Implements #56 (component C of the BMAD harness).

Adds the parseable backlog `_bmad-output/implementation-artifacts/stories/backlog/STORY-001..005.md` in canonical format, `scripts/bmad-backlog.mjs --validate` (Node built-ins; emits a machine-readable index), and `sprint-status.yaml` entries.

`--validate` exits 0 with `5/5 stories valid`. **STORY-003 (Zod IPC) and STORY-004 (Drizzle runner) are marked `Reserved: supervised`** and are NOT implemented here.

**Guardrails:** no token edits, no new deps, `package.json` untouched. **Human merge only.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016ks3FkxAuBsEScL5n2aQKG)_