### PR TITLE
fix(core): remove unused @emuz/database and drizzle-orm deps

### DIFF
--- a/libs/core/package.json
+++ b/libs/core/package.json
@@ -6,10 +6,8 @@
   "main": "./index.js",
   "types": "./index.d.ts",
   "dependencies": {
-    "@emuz/database": "workspace:*",
     "@emuz/platform": "workspace:*",
     "@emuz/storage": "workspace:*",
-    "drizzle-orm": "^0.45.1",
     "uuid": "^11.1.0",
     "zustand": "^5.0.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -350,18 +350,12 @@ importers:
 
   libs/core:
     dependencies:
-      '@emuz/database':
-        specifier: workspace:*
-        version: link:../database
       '@emuz/platform':
         specifier: workspace:*
         version: link:../platform
       '@emuz/storage':
         specifier: workspace:*
         version: link:../storage
-      drizzle-orm:
-        specifier: ^0.45.1
-        version: 0.45.1(@op-engineering/op-sqlite@8.0.3(react-native@0.81.5(@babel/core@7.28.5)(@react-native-community/cli@20.1.0(typescript@5.7.3))(@react-native/metro-config@0.76.5(@babel/core@7.28.5))(@types/react@18.3.27)(react@19.1.0))(react@19.1.0))(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)
       react:
         specifier: '>=18.0.0'
         version: 19.1.0
@@ -3419,6 +3413,7 @@ packages:
 
   '@testing-library/react-native@12.9.0':
     resolution: {integrity: sha512-wIn/lB1FjV2N4Q7i9PWVRck3Ehwq5pkhAef5X5/bmQ78J/NoOsGbVY2/DG5Y9Lxw+RfE+GvSEh/fe5Tz6sKSvw==}
+    deprecated: React Native Testing Library v12 is no longer maintained. Please upgrade to v13 or v14.
     peerDependencies:
       jest: '>=28.0.0'
       react: '>=16.8.0'
@@ -3730,6 +3725,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
     resolution: {integrity: sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==}
@@ -3978,6 +3974,7 @@ packages:
   '@xmldom/xmldom@0.8.11':
     resolution: {integrity: sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==}
     engines: {node: '>=10.0.0'}
+    deprecated: this version has critical issues, please update to the latest version
 
   '@xtuc/ieee754@1.2.0':
     resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
@@ -8558,6 +8555,7 @@ packages:
   prebuild-install@7.1.3:
     resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
     engines: {node: '>=10'}
+    deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
     hasBin: true
 
   prelude-ls@1.2.1:
@@ -9600,10 +9598,12 @@ packages:
   tar@6.2.1:
     resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
     engines: {node: '>=10'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   tar@7.5.2:
     resolution: {integrity: sha512-7NyxrTE4Anh8km8iEy7o0QYPs+0JKBTj5ZaqHg6B39erLg0qYXN3BijtShwbsNSvQ+LN75+KV+C4QR/f6Gwnpg==}
     engines: {node: '>=18'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   telnet-client@1.2.8:
     resolution: {integrity: sha512-W+w4k3QAmULVNhBVT2Fei369kGZCh/TH25M7caJAXW+hLxwoQRuw0di3cX4l0S9fgH3Mvq7u+IFMoBDpEw/eIg==}
@@ -9953,6 +9953,7 @@ packages:
 
   uuid@7.0.3:
     resolution: {integrity: sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   v8-to-istanbul@9.3.0:
@@ -13566,12 +13567,6 @@ snapshots:
       - '@swc/core'
       - debug
 
-  '@op-engineering/op-sqlite@8.0.3(react-native@0.81.5(@babel/core@7.28.5)(@react-native-community/cli@20.1.0(typescript@5.7.3))(@react-native/metro-config@0.76.5(@babel/core@7.28.5))(@types/react@18.3.27)(react@19.1.0))(react@19.1.0)':
-    dependencies:
-      react: 19.1.0
-      react-native: 0.81.5(@babel/core@7.28.5)(@react-native-community/cli@20.1.0(typescript@5.7.3))(@react-native/metro-config@0.76.5(@babel/core@7.28.5))(@types/react@18.3.27)(react@19.1.0)
-    optional: true
-
   '@op-engineering/op-sqlite@8.0.3(react-native@0.81.5(@babel/core@7.28.5)(@react-native-community/cli@20.1.0(typescript@5.7.3))(@react-native/metro-config@0.76.5(@babel/core@7.28.5))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)':
     dependencies:
       react: 19.1.0
@@ -14095,16 +14090,6 @@ snapshots:
       react-native: 0.76.5(@babel/core@7.28.5)(@babel/preset-env@7.28.5(@babel/core@7.28.5))(@react-native-community/cli-server-api@20.1.0)(@types/react@18.3.27)(encoding@0.1.13)(react@19.1.0)
     optionalDependencies:
       '@types/react': 18.3.27
-
-  '@react-native/virtualized-lists@0.81.5(@types/react@18.3.27)(react-native@0.81.5(@babel/core@7.28.5)(@react-native-community/cli@20.1.0(typescript@5.7.3))(@react-native/metro-config@0.76.5(@babel/core@7.28.5))(@types/react@18.3.27)(react@19.1.0))(react@19.1.0)':
-    dependencies:
-      invariant: 2.2.4
-      nullthrows: 1.1.1
-      react: 19.1.0
-      react-native: 0.81.5(@babel/core@7.28.5)(@react-native-community/cli@20.1.0(typescript@5.7.3))(@react-native/metro-config@0.76.5(@babel/core@7.28.5))(@types/react@18.3.27)(react@19.1.0)
-    optionalDependencies:
-      '@types/react': 18.3.27
-    optional: true
 
   '@react-native/virtualized-lists@0.81.5(@types/react@19.1.17)(react-native@0.81.5(@babel/core@7.28.5)(@react-native-community/cli@20.1.0(typescript@5.7.3))(@react-native/metro-config@0.76.5(@babel/core@7.28.5))(@types/react@19.1.17)(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -16984,12 +16969,6 @@ snapshots:
       '@esbuild-kit/esm-loader': 2.6.5
       esbuild: 0.25.12
       tsx: 4.21.0
-
-  drizzle-orm@0.45.1(@op-engineering/op-sqlite@8.0.3(react-native@0.81.5(@babel/core@7.28.5)(@react-native-community/cli@20.1.0(typescript@5.7.3))(@react-native/metro-config@0.76.5(@babel/core@7.28.5))(@types/react@18.3.27)(react@19.1.0))(react@19.1.0))(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0):
-    optionalDependencies:
-      '@op-engineering/op-sqlite': 8.0.3(react-native@0.81.5(@babel/core@7.28.5)(@react-native-community/cli@20.1.0(typescript@5.7.3))(@react-native/metro-config@0.76.5(@babel/core@7.28.5))(@types/react@18.3.27)(react@19.1.0))(react@19.1.0)
-      '@types/better-sqlite3': 7.6.13
-      better-sqlite3: 11.10.0
 
   drizzle-orm@0.45.1(@op-engineering/op-sqlite@8.0.3(react-native@0.81.5(@babel/core@7.28.5)(@react-native-community/cli@20.1.0(typescript@5.7.3))(@react-native/metro-config@0.76.5(@babel/core@7.28.5))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0):
     optionalDependencies:
@@ -21588,54 +21567,6 @@ snapshots:
       - encoding
       - supports-color
       - utf-8-validate
-
-  react-native@0.81.5(@babel/core@7.28.5)(@react-native-community/cli@20.1.0(typescript@5.7.3))(@react-native/metro-config@0.76.5(@babel/core@7.28.5))(@types/react@18.3.27)(react@19.1.0):
-    dependencies:
-      '@jest/create-cache-key-function': 29.7.0
-      '@react-native/assets-registry': 0.81.5
-      '@react-native/codegen': 0.81.5(@babel/core@7.28.5)
-      '@react-native/community-cli-plugin': 0.81.5(@react-native-community/cli@20.1.0(typescript@5.7.3))(@react-native/metro-config@0.76.5(@babel/core@7.28.5))
-      '@react-native/gradle-plugin': 0.81.5
-      '@react-native/js-polyfills': 0.81.5
-      '@react-native/normalize-colors': 0.81.5
-      '@react-native/virtualized-lists': 0.81.5(@types/react@18.3.27)(react-native@0.81.5(@babel/core@7.28.5)(@react-native-community/cli@20.1.0(typescript@5.7.3))(@react-native/metro-config@0.76.5(@babel/core@7.28.5))(@types/react@18.3.27)(react@19.1.0))(react@19.1.0)
-      abort-controller: 3.0.0
-      anser: 1.4.10
-      ansi-regex: 5.0.1
-      babel-jest: 29.7.0(@babel/core@7.28.5)
-      babel-plugin-syntax-hermes-parser: 0.29.1
-      base64-js: 1.5.1
-      commander: 12.1.0
-      flow-enums-runtime: 0.0.6
-      glob: 7.2.3
-      invariant: 2.2.4
-      jest-environment-node: 29.7.0
-      memoize-one: 5.2.1
-      metro-runtime: 0.83.3
-      metro-source-map: 0.83.3
-      nullthrows: 1.1.1
-      pretty-format: 29.7.0
-      promise: 8.3.0
-      react: 19.1.0
-      react-devtools-core: 6.1.5
-      react-refresh: 0.14.2
-      regenerator-runtime: 0.13.11
-      scheduler: 0.26.0
-      semver: 7.7.3
-      stacktrace-parser: 0.1.11
-      whatwg-fetch: 3.6.20
-      ws: 6.2.3
-      yargs: 17.7.2
-    optionalDependencies:
-      '@types/react': 18.3.27
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@react-native-community/cli'
-      - '@react-native/metro-config'
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-    optional: true
 
   react-native@0.81.5(@babel/core@7.28.5)(@react-native-community/cli@20.1.0(typescript@5.7.3))(@react-native/metro-config@0.76.5(@babel/core@7.28.5))(@types/react@19.1.17)(react@18.3.1):
     dependencies:


### PR DESCRIPTION
Fixes #65.

`core:lint` fails on `main` via `@nx/dependency-checks`: `libs/core` declares `@emuz/database` and `drizzle-orm` but imports neither (only a comment in `WidgetService.ts` references drizzle). Leftovers from the Drizzle migration (story 1.7).

- Removes the two unused deps from `libs/core/package.json`.
- Updates `pnpm-lock.yaml` via `pnpm install --lockfile-only` (so `--frozen-lockfile` install stays valid).
- No source change; both packages remain declared/used by other projects (mobile/desktop/database).

This is a **pre-existing `main` failure**, independent of the BMAD harness — it surfaced because harness PR #64 is the first PR to `main` to trigger CI. Merging this unblocks #64's CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016ks3FkxAuBsEScL5n2aQKG)_